### PR TITLE
Update libxmljs to 0.18  🎉

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "gulp-resx2",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A resx file converter plugin for gulp",
   "main": "index.js",
   "dependencies": {
-    "libxmljs": "0.15.0",
+    "libxmljs": "^0.18.0",
     "gulp-util": "^3.0.1",
     "through2": "^0.6.3"
   },


### PR DESCRIPTION
Fixes build failures on node 6. `gulp-resx2` now builds successfully on node v6.9.1.

Also adding carret range to allow for patch updates. 

Bump minor version to `1.1.0`

Closes #3 

All tests passing.

Verified no regressions in large project with multiple resx files.

