### PR TITLE
Add new nodejs versions to travis build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.12
+  - 4
+  - 6


### PR DESCRIPTION
Adding new nodejs version to the travis build. 

Build is failing on node 6 and this should be covered by ci. 

#4 will fix failure on node 6 (See #3). Rebase after #4 is merged. 